### PR TITLE
fix: respect explicit diffColors overrides

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -966,7 +966,10 @@ function applyDiffPalette(): void {
 
 	DIVIDER = `${FG_RULE}│${D_RST}`;
 	DEFAULT_DIFF_COLORS = { fgAdd: FG_ADD, fgDel: FG_DEL, fgCtx: FG_DIM };
-	autoDerivePending = true;
+	// Only trigger auto-derive when the user did NOT supply an explicit
+	// preset or per-color override; otherwise we would overwrite their config
+	// with the hardcoded dark palette on first render.
+	autoDerivePending = !hasExplicitBgConfig;
 }
 
 function resolveDiffColors(theme?: any): DiffColors {


### PR DESCRIPTION
Hey 👋

Fix for #2.

Tried to get my `diffColors` overrides in settings.json to take effect on a light terminal — turned out `applyDiffPalette()` sets `autoDerivePending = true` unconditionally at the end, and then `resolveDiffColors()` runs `autoDeriveBgFromTheme()` on first render which overwrites all the `BG_*` values I'd just configured with the hardcoded dark palette. `hasExplicitBgConfig` is tracked but never actually read to gate this.

One-line fix: use the flag that's already being tracked.

```diff
- autoDerivePending = true;
+ autoDerivePending = !hasExplicitBgConfig;
```

This matches what `@heyhuynhgiabuu/pi-diff` does upstream (its `src/index.ts:359`).

Added a short comment above the line so future-me (or future-you) doesn't accidentally revert it while refactoring.

## What I checked before pushing

- No `diffColors`, no `diffTheme` → auto-derive still runs exactly like before (default behaviour unchanged) ✅
- `diffTheme: "midnight"` → preset's bg values survive, auto-derive skipped ✅
- Custom light palette via `diffColors` → finally renders 🙌

No other code paths touch `autoDerivePending`, so the blast radius is pretty small.

Let me know if you'd rather structure this differently (e.g. a dedicated `shouldAutoDerive()` helper, or reading the flag inside `resolveDiffColors` instead of setting it inside `applyDiffPalette`) — happy to restructure.

Thanks again for the extension, it's genuinely my favourite pi addition.
